### PR TITLE
Fix #13 segmentation fault on build xml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         config:
           - {name: "Ubuntu-20.04-Release", os: ubuntu-20.04, python: "3.9", cmakegen: "Release", llvm: "x86_64-linux-gnu-ubuntu-18.04", llvm_prefix: "clang+llvm", llvm_version: "13.0.1", llvm_postfix: "-", llvm-ext: "tar.xz", unpack: "tar xf", conan: "1.59.0", packages: "libboost-filesystem-dev cmake make perl g++ gdb libfl2 libfl-dev zlib1g zlib1g-dev ccache numactl perl-doc autoconf flex bison"}
           #- {name: "Ubuntu-22.04-Release", os: ubuntu-22.04, python: "3.9", cmakegen: "Release", verilator: "v4.228", llvm: "src", llvm_prefix: "llvm-project",  llvm_version: "13.0.1", llvm_postfix: ".", llvm-ext: "tar.xz", unpack: "tar xf", conan: "1.59.0", packages: "libboost-filesystem-dev cmake make perl g++ gdb libfl2 libfl-dev zlib1g zlib1g-dev ccache numactl perl-doc autoconf flex bison libncurses5"}
-        verilator: ["v4.202", "v4.228"]
+        verilator: ["v4.202", "v4.204", "v4.228"]
 
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.name }}-verilator_${{ matrix.verilator }}_requirements
@@ -98,7 +98,7 @@ jobs:
         config:
           - {name: "Ubuntu-20.04-Release", os: ubuntu-20.04, python: "3.9", cmakegen: "Release", llvm: "x86_64-linux-gnu-ubuntu-18.04", llvm_prefix: "clang+llvm", llvm_version: "13.0.1", llvm_postfix: "-", llvm-ext: "tar.xz", unpack: "tar xf", conan: "1.59.0", packages: "libboost-filesystem-dev cmake make perl g++ gdb libfl2 libfl-dev zlib1g zlib1g-dev ccache numactl perl-doc autoconf flex bison"}
           #- {name: "Ubuntu-22.04-Release", os: ubuntu-22.04, python: "3.9", cmakegen: "Release", verilator: "v4.228", llvm: "src", llvm_prefix: "llvm-project",  llvm_version: "13.0.1", llvm_postfix: ".", llvm-ext: "tar.xz", unpack: "tar xf", conan: "1.59.0", packages: "libboost-filesystem-dev cmake make perl g++ gdb libfl2 libfl-dev zlib1g zlib1g-dev ccache numactl perl-doc autoconf flex bison libncurses5"}
-        verilator: ["v4.202", "v4.228"]
+        verilator: ["v4.202", "v4.204", "v4.228"]
 
     needs: requirements
     runs-on: ${{ matrix.config.os }}
@@ -236,7 +236,7 @@ jobs:
         config:
           - {name: "Ubuntu-20.04-Release", os: ubuntu-20.04, python: "3.9", cmakegen: "Release", llvm: "x86_64-linux-gnu-ubuntu-18.04", llvm_prefix: "clang+llvm", llvm_version: "13.0.1", llvm_postfix: "-", llvm-ext: "tar.xz", unpack: "tar xf", conan: "1.59.0", packages: "libboost-filesystem-dev cmake make perl g++ gdb libfl2 libfl-dev zlib1g zlib1g-dev ccache numactl perl-doc autoconf flex bison"}
           #- {name: "Ubuntu-22.04-Release", os: ubuntu-22.04, python: "3.9", cmakegen: "Release", verilator: "v4.228", llvm: "src", llvm_prefix: "llvm-project",  llvm_version: "13.0.1", llvm_postfix: ".", llvm-ext: "tar.xz", unpack: "tar xf", conan: "1.59.0", packages: "libboost-filesystem-dev cmake make perl g++ gdb libfl2 libfl-dev zlib1g zlib1g-dev ccache numactl perl-doc autoconf flex bison libncurses5"}
-        verilator: ["v4.202", "v4.228"]
+        verilator: ["v4.202", "v4.204", "v4.228"]
         duts: ["foo", "cv32e40p", "cv32e40s", "cva6"]
 
     needs: build

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -208,7 +208,7 @@ std::vector<std::string> VrtlmodCore::prepare_headers(const std::vector<std::str
 std::string VrtlmodCore::get_vrtltopheader_filename(void) const
 {
     std::string top_name = get_top_cell().get_type();
-#if VRTLMOD_VERILATOR_VERSION <= 4202
+#if VRTLMOD_VERILATOR_VERSION <= 4204
 
 #else // VRTLMOD_VERILATOR_VERSION <= 4228
     util::strhelp::replace(top_name, "___024root", "");
@@ -218,7 +218,7 @@ std::string VrtlmodCore::get_vrtltopheader_filename(void) const
 std::string VrtlmodCore::get_vrtltopsymsheader_filename(void) const
 {
     std::string top_name = get_top_cell().get_type();
-#if VRTLMOD_VERILATOR_VERSION <= 4202
+#if VRTLMOD_VERILATOR_VERSION <= 4204
 
 #else // VRTLMOD_VERILATOR_VERSION <= 4228
     util::strhelp::replace(top_name, "___024root", "");
@@ -468,7 +468,7 @@ const types::Variable *VrtlmodCore::add_variable(const clang::FieldDecl *variabl
         lsb = decl_source_code_text.substr(second_col, third_col - second_col);
         var_type = std::regex_search(decl_source_code_text, std::regex("/\\*VL_INW*\\*/")) ? "in" : "out";
         auto cxx_base_type_str = decl_source_code_text.substr(0, decl_source_code_text.find(id) - 1);
-#if VRTLMOD_VERILATOR_VERSION <= 4202
+#if VRTLMOD_VERILATOR_VERSION <= 4204
         auto openbrace = decl_source_code_text.find('[');
         auto closebrace = decl_source_code_text.find(']');
         cxx_base_type_str += decl_source_code_text.substr(openbrace, closebrace - openbrace + 1);
@@ -777,7 +777,7 @@ void VrtlmodCore::build_xml()
         });
 
     std::string top_name = get_top_cell().get_type();
-#if VRTLMOD_VERILATOR_VERSION <= 4202
+#if VRTLMOD_VERILATOR_VERSION <= 4204
 
 #else // VRTLMOD_VERILATOR_VERSION <= 4228
     util::strhelp::replace(top_name, "___024root", "");

--- a/src/core/vrtlparse.cpp
+++ b/src/core/vrtlparse.cpp
@@ -90,7 +90,7 @@ void VrtlParser::addMatcher(clang::ast_matchers::MatchFinder &finder)
 
     const auto topref_decl =
         fieldDecl(allOf(isPublic(), hasAncestor(symtable_decl),
-#if VRTLMOD_VERILATOR_VERSION <= 4202
+#if VRTLMOD_VERILATOR_VERSION <= 4204
                         anyOf(hasType(pointsTo(sc_module_decl)), hasType(pointsTo(cc_module_decl)),
                               hasType(references(sc_module_decl)), hasType(references(cc_module_decl))),
                         matchesName("::TOPp")
@@ -106,7 +106,7 @@ void VrtlParser::addMatcher(clang::ast_matchers::MatchFinder &finder)
         fieldDecl(allOf(isPublic(), anyOf(hasAncestor(sc_module_decl), hasAncestor(cc_module_decl)),
                         anyOf(hasType(pointsTo(sc_module_decl)), hasType(pointsTo(cc_module_decl)),
                               hasType(references(sc_module_decl)), hasType(references(cc_module_decl))),
-#if VRTLMOD_VERILATOR_VERSION <= 4202
+#if VRTLMOD_VERILATOR_VERSION <= 4204
                         unless(matchesName("::TOPp")
 #else // VRTLMOD_VERILATOR_VERSION <= 4.228
                         unless(matchesName("::TOP")
@@ -124,7 +124,7 @@ void VrtlParser::addMatcher(clang::ast_matchers::MatchFinder &finder)
     const auto signal_decl =
         fieldDecl(
             isPublic(), anyOf(hasAncestor(sc_module_decl), hasAncestor(cc_module_decl)), unless(vrtl_internal),
-#if VRTLMOD_VERILATOR_VERSION <= 4202
+#if VRTLMOD_VERILATOR_VERSION <= 4204
             unless(hasType(pointsTo(
                 cxxRecordDecl()))) // we can not use {sc,cc}_module_decl fine grained matching because verilator builds
                                    // its dependant modules with forward declarations not resolvable from header AST
@@ -140,7 +140,7 @@ void VrtlParser::addMatcher(clang::ast_matchers::MatchFinder &finder)
 
     const auto compound_of_sequent_func =
         compoundStmt(hasParent(functionDecl(
-#if VRTLMOD_VERILATOR_VERSION <= 4202
+#if VRTLMOD_VERILATOR_VERSION <= 4204
             anyOf(
                 matchesName("::_sequent__*"),
                 matchesName("::_multiclk__*")

--- a/src/passes/analyze.cpp
+++ b/src/passes/analyze.cpp
@@ -98,7 +98,7 @@ void AnalyzePass::action(const VrtlParser &parser, const clang::ast_matchers::Ma
     else if (binop = Result.Nodes.getNodeAs<clang::BinaryOperator>("sea_binary_array_3d"))
     {
         LOG_INFO("{sea_binary_array_3d}:", util::logging::dump_to_str<const clang::Stmt *>(binop, ctx));
-        #if VRTLMOD_VERILATOR_VERSION <= 4202
+        #if VRTLMOD_VERILATOR_VERSION <= 4204
         #else // VERILATOR_VERSION <= 4.228
         LOG_FATAL("Matched unexpected sequential assignment!");
         #endif
@@ -114,7 +114,7 @@ void AnalyzePass::action(const VrtlParser &parser, const clang::ast_matchers::Ma
     else if (binop = Result.Nodes.getNodeAs<clang::BinaryOperator>("sea_binary_array_2d"))
     {
         LOG_INFO("{sea_binary_array_2d}:", util::logging::dump_to_str<const clang::Stmt *>(binop, ctx));
-        #if VRTLMOD_VERILATOR_VERSION <= 4202
+        #if VRTLMOD_VERILATOR_VERSION <= 4204
         #else // VERILATOR_VERSION <= 4.228
         LOG_FATAL("Matched unexpected sequential assignment!");
         #endif

--- a/src/vapi/generator.cpp
+++ b/src/vapi/generator.cpp
@@ -54,7 +54,7 @@ std::string VapiGenerator::get_targetdictionary_relpath(void) const
 std::string VapiGenerator::get_apiheader_filename(void) const
 {
     std::string top_name = get_core().get_top_cell().get_type();
-#if VRTLMOD_VERILATOR_VERSION <= 4202
+#if VRTLMOD_VERILATOR_VERSION <= 4204
     // nothing to do here
 #else // VRTLMOD_VERILATOR_VERSION <= 4228
     util::strhelp::replace(top_name, "___024root", "");
@@ -64,7 +64,7 @@ std::string VapiGenerator::get_apiheader_filename(void) const
 std::string VapiGenerator::get_apisource_filename(void) const
 {
     std::string top_name = get_core().get_top_cell().get_type();
-#if VRTLMOD_VERILATOR_VERSION <= 4202
+#if VRTLMOD_VERILATOR_VERSION <= 4204
     // nothing to do here
 #else // VRTLMOD_VERILATOR_VERSION <= 4228
     util::strhelp::replace(top_name, "___024root", "");

--- a/src/vapi/templates/vrtlmodapi_header.cpp
+++ b/src/vapi/templates/vrtlmodapi_header.cpp
@@ -33,7 +33,7 @@ std::string VapiGenerator::VapiHeader::generate_body(void) const
     const auto &core = gen_.get_core();
 
     std::string top_name = core.get_top_cell().get_type();
-#if VRTLMOD_VERILATOR_VERSION <= 4202
+#if VRTLMOD_VERILATOR_VERSION <= 4204
 #else // VRTLMOD_VERILATOR_VERSION <= 4228
     util::strhelp::replace(top_name, "___024root", "");
 #endif

--- a/src/vapi/templates/vrtlmodapi_source.cpp
+++ b/src/vapi/templates/vrtlmodapi_source.cpp
@@ -31,7 +31,7 @@ namespace vrtlmod
 namespace vapi
 {
 static const char *SYMBOLTABLE_NAME =
-#if VRTLMOD_VERILATOR_VERSION <= 4202
+#if VRTLMOD_VERILATOR_VERSION <= 4204
     "__VlSymsp";
 #else // VRTLMOD_VERILATOR_VERSION <= 4228
     "vlSymsp";
@@ -44,7 +44,7 @@ std::string VapiGenerator::VapiSource::generate_body(void) const
 
     const auto &core = gen_.get_core();
     std::string top_name = core.get_top_cell().get_type();
-#if VRTLMOD_VERILATOR_VERSION <= 4202
+#if VRTLMOD_VERILATOR_VERSION <= 4204
 #else // VRTLMOD_VERILATOR_VERSION <= 4228
     util::strhelp::replace(top_name, "___024root", "");
 #endif
@@ -77,7 +77,7 @@ std::string VapiGenerator::VapiSource::generate_body(void) const
 
     auto get_prefix = [&](types::Cell const *c, std::string module_instance) -> std::string
     {
-//#if VRTLMOD_VERILATOR_VERSION <= 4202
+//#if VRTLMOD_VERILATOR_VERSION <= 4204
 //#else // VRTLMOD_VERILATOR_VERSION <= 4228
 //        return (*c == core.get_top_cell()) ? "rootp" : module_instance;
 //#endif
@@ -87,7 +87,7 @@ std::string VapiGenerator::VapiSource::generate_body(void) const
     auto get_memberstr = [&](types::Cell const *c, const types::Target &t, const std::string &prefix) -> std::string
     {
         return util::concat(
-#if VRTLMOD_VERILATOR_VERSION <= 4202
+#if VRTLMOD_VERILATOR_VERSION <= 4204
             SYMBOLTABLE_NAME, "->", prefix, (*c == core.get_top_cell()) ? "->" : "."
 #else // VRTLMOD_VERILATOR_VERSION <= 4228
             "rootp->", SYMBOLTABLE_NAME, "->", prefix, "."


### PR DESCRIPTION
Fix Issue #13 

---
Problem in Verilator Version checks that did not set the non-root Class variable hosting of newer Verilator version (>v4.204) only until <=v4.202, e.g. v4.204 was treated as root Class based which is it not.